### PR TITLE
Release 0.6.4 — bump vendor pin to abap-mcp-adt-powerup v4.8.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "sc4sap",
       "description": "Claude Code plugin for SAP ABAP development on On-Premise S/4HANA — 25 specialized agents, 16 workflow skills (create-program with Phase 4/6 hardening + multi-executor split, create-object, program-to-spec, compare-programs, analyze-code/symptom/cbo-obj, ask-consultant, deep-interview, team, release, setup, internal trust-session), 4-Tier context loading, Sonnet/Opus model routing, OK_CODE binding pattern, paradigm-split Clean ABAP, and SPRO config reference for 14 modules.",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "author": {
         "name": "paek seunghyun"
       },
@@ -60,5 +60,5 @@
       ]
     }
   ],
-  "version": "0.6.3"
+  "version": "0.6.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sc4sap",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Claude Code plugin for SAP ABAP development — 25 specialized agents (10 core + BC + 14 module consultants), 16 workflow skills (create-program with Phase 4/6 hardening & multi-executor split, create-object, program-to-spec, compare-programs, analyze-code/symptom/cbo-obj, ask-consultant, deep-interview, team, release, setup/mcp-setup, sap-option/sap-doctor, internal trust-session), 4-Tier context loading (Tier 1 safety baseline + Tier 2 role-mandatory + Tier 3 triggered + Tier 4 per-task kit), Sonnet/Opus/Haiku model routing, OK_CODE binding pattern for Procedural screens, paradigm-split Clean ABAP, 4 RFC backends (soap/native/gateway/odata), SPRO config for 14 modules.",
   "author": {
     "name": "paek seunghyun"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to **SuperClaude for SAP (sc4sap)** will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4] — 2026-04-22
+
+### Changed — Vendor pin bump
+
+- `scripts/build-mcp-server.mjs` `DEFAULT_PINNED_SHA` → `b41d4df546e2cccfa3f6693b656e16868b6facb6` (abap-mcp-adt-powerup **v4.8.1**, previously pinned at a pre-v4.8.0 SHA). npm installers of sc4sap 0.6.4 now receive the ECC DDIC write fallback vendored into the plugin.
+
+No other functional changes — 0.6.4 is a pure vendor-pin follow-up to 0.6.3.
+
 ## [0.6.3] — 2026-04-22
 
 ### Added — ECC DDIC write path via OData RFC fallback

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babamba2/superclaude-for-sap",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "SuperClaude for SAP — Claude Code plugin for SAP On-Premise S/4HANA development",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/build-mcp-server.mjs
+++ b/scripts/build-mcp-server.mjs
@@ -32,7 +32,7 @@ const LAUNCHER = resolve(VENDOR_DIR, 'dist', 'server', 'launcher.js');
 // checks out exactly this SHA so a compromised upstream main cannot push code
 // into user machines. Bump this on a vetted vendor upgrade, cut a new sc4sap
 // release, document the old → new SHA in release notes.
-const DEFAULT_PINNED_SHA = 'f21b3428fc3c9fc08cf9450e480c1e7dec2a52fc';
+const DEFAULT_PINNED_SHA = 'b41d4df546e2cccfa3f6693b656e16868b6facb6';
 // Env override for maintainers / CI testing an unreleased vendor commit. Must
 // be a 40-hex SHA; anything else is rejected so the override cannot be an
 // accidental branch name like "main".


### PR DESCRIPTION
## Summary

- Pure **vendor-pin follow-up to 0.6.3**. `scripts/build-mcp-server.mjs` `DEFAULT_PINNED_SHA` → `b41d4df546e2cccfa3f6693b656e16868b6facb6` (= abap-mcp-adt-powerup **v4.8.1**, which ships the ECC DDIC OData-RFC write fallback).
- Previous pin was `f21b342` (pre-v4.8.0), so npm installers of sc4sap 0.6.3 would have received vendor without ECC DDIC support.
- Version bump 0.6.3 → 0.6.4 across package.json + .claude-plugin/{plugin,marketplace}.json + CHANGELOG.md `[0.6.4]`.

No functional code changes beyond the pin constant.

## Test plan

- [x] Smoke already validated on 0.6.3 — 0.6.4 is a constant-only bump
- [ ] Post-merge: tag `v0.6.4` → `npm publish` — prepublishOnly re-clones vendor at new pin → confirm vendor HEAD == `b41d4df...`
- [ ] After publish: `npm view @babamba2/superclaude-for-sap version` → `0.6.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)