### PR TITLE
Release 0.6.5 — simplify prepublishOnly to tsc only

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "sc4sap",
       "description": "Claude Code plugin for SAP ABAP development on On-Premise S/4HANA — 25 specialized agents, 16 workflow skills (create-program with Phase 4/6 hardening + multi-executor split, create-object, program-to-spec, compare-programs, analyze-code/symptom/cbo-obj, ask-consultant, deep-interview, team, release, setup, internal trust-session), 4-Tier context loading, Sonnet/Opus model routing, OK_CODE binding pattern, paradigm-split Clean ABAP, and SPRO config reference for 14 modules.",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "author": {
         "name": "paek seunghyun"
       },
@@ -60,5 +60,5 @@
       ]
     }
   ],
-  "version": "0.6.4"
+  "version": "0.6.5"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sc4sap",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Claude Code plugin for SAP ABAP development — 25 specialized agents (10 core + BC + 14 module consultants), 16 workflow skills (create-program with Phase 4/6 hardening & multi-executor split, create-object, program-to-spec, compare-programs, analyze-code/symptom/cbo-obj, ask-consultant, deep-interview, team, release, setup/mcp-setup, sap-option/sap-doctor, internal trust-session), 4-Tier context loading (Tier 1 safety baseline + Tier 2 role-mandatory + Tier 3 triggered + Tier 4 per-task kit), Sonnet/Opus/Haiku model routing, OK_CODE binding pattern for Procedural screens, paradigm-split Clean ABAP, 4 RFC backends (soap/native/gateway/odata), SPRO config for 14 modules.",
   "author": {
     "name": "paek seunghyun"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to **SuperClaude for SAP (sc4sap)** will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] — 2026-04-22
+
+### Changed — Publish workflow
+
+- `prepublishOnly` simplified from `"npm run build"` to `"tsc"`. The full `build` script (which also runs `scripts/build-mcp-server.mjs` to clone and verify the vendor at the pinned SHA) is preserved for manual maintainer use (`npm run build`) but no longer executes during `npm publish`.
+- Rationale: `vendor/` is not shipped in the tgz (`files` field excludes it) and the bridge re-clones it lazily at install-time, so publishing had no reason to materialize a ~500MB `vendor/abap-mcp-adt/` under the project root. This was a quality-of-life fix for maintainers.
+
+No other changes — 0.6.5 is a pure publish-workflow follow-up to 0.6.4.
+
 ## [0.6.4] — 2026-04-22
 
 ### Changed — Vendor pin bump

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babamba2/superclaude-for-sap",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "SuperClaude for SAP — Claude Code plugin for SAP On-Premise S/4HANA development",
   "type": "module",
   "main": "dist/index.js",
@@ -37,7 +37,7 @@
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src",
     "format": "prettier --write src/**/*.ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "tsc"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",


### PR DESCRIPTION
## Summary

- `prepublishOnly` simplified from `"npm run build"` → `"tsc"`. `npm publish` no longer clones vendor into the project root.
- `npm run build` (full build with `scripts/build-mcp-server.mjs`) kept intact for manual use.
- Version bump 0.6.4 → 0.6.5.

Pure publish-workflow follow-up to 0.6.4 — no functional or vendor-pin changes.

## Test plan

- [ ] Post-merge: `npm publish` runs `tsc` only, no `vendor/` materializes under project root
- [ ] `npm view @babamba2/superclaude-for-sap version` → `0.6.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)