### PR TITLE
chore(release): catch main up to 0.6.11 + marketplace manifest sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "sc4sap",
       "description": "Claude Code plugin for SAP ABAP development on On-Premise S/4HANA — 25 specialized agents, 16 workflow skills (create-program with Phase 4/6 hardening + multi-executor split, create-object, program-to-spec, compare-programs, analyze-code/symptom/cbo-obj, ask-consultant, deep-interview, team, release, setup, internal trust-session), 4-Tier context loading, Sonnet/Opus model routing, OK_CODE binding pattern, paradigm-split Clean ABAP, and SPRO config reference for 14 modules.",
-      "version": "0.6.5",
+      "version": "0.6.11",
       "author": {
         "name": "paek seunghyun"
       },
@@ -60,5 +60,5 @@
       ]
     }
   ],
-  "version": "0.6.5"
+  "version": "0.6.11"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sc4sap",
-  "version": "0.6.5",
+  "version": "0.6.11",
   "description": "Claude Code plugin for SAP ABAP development — 25 specialized agents (10 core + BC + 14 module consultants), 16 workflow skills (create-program with Phase 4/6 hardening & multi-executor split, create-object, program-to-spec, compare-programs, analyze-code/symptom/cbo-obj, ask-consultant, deep-interview, team, release, setup/mcp-setup, sap-option/sap-doctor, internal trust-session), 4-Tier context loading (Tier 1 safety baseline + Tier 2 role-mandatory + Tier 3 triggered + Tier 4 per-task kit), Sonnet/Opus/Haiku model routing, OK_CODE binding pattern for Procedural screens, paradigm-split Clean ABAP, 4 RFC backends (soap/native/gateway/odata), SPRO config for 14 modules.",
   "author": {
     "name": "paek seunghyun"

--- a/.github/workflows/ci-diagnose.yml
+++ b/.github/workflows/ci-diagnose.yml
@@ -1,0 +1,110 @@
+name: CI diagnose
+
+# Runs AFTER the main CI workflow completes. If CI failed, invokes the
+# Anthropic API to produce a structured diagnosis of the failure, posts it
+# as a comment on the originating PR, and uploads it as an artifact.
+#
+# For the comment step to work, the repo must have a secret named
+# ANTHROPIC_API_KEY. Add at:
+#   Repo → Settings → Secrets and variables → Actions → New repository secret
+#
+# Security note: workflow_run always executes using the workflow definition
+# on the DEFAULT BRANCH and with write permissions scoped here. This means
+# PR branches cannot modify ci-diagnose.yml to grant themselves elevated
+# access — the diagnose run is always the main-branch version.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  diagnose:
+    # Only diagnose actual failures; skip success / cancelled / skipped.
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Checkout (main branch — diagnose script source of truth)
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch failed-step log from triggering run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/ci-diagnose
+          # --log-failed is scoped to the failed steps only; much smaller than --log
+          gh run view ${{ github.event.workflow_run.id }} \
+            --repo ${{ github.repository }} \
+            --log-failed > /tmp/ci-diagnose/fail.log || true
+          if [ ! -s /tmp/ci-diagnose/fail.log ]; then
+            echo "[fetch-log] --log-failed was empty, falling back to full log"
+            gh run view ${{ github.event.workflow_run.id }} \
+              --repo ${{ github.repository }} \
+              --log > /tmp/ci-diagnose/fail.log || true
+          fi
+          ls -la /tmp/ci-diagnose/
+          wc -l /tmp/ci-diagnose/fail.log || true
+
+      - name: Resolve PR number for this run
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr=$(gh run view ${{ github.event.workflow_run.id }} \
+            --repo ${{ github.repository }} \
+            --json pullRequests \
+            --jq '.pullRequests[0].number // empty' 2>/dev/null || true)
+          if [ -z "$pr" ]; then
+            echo "[pr-lookup] no associated PR — will skip comment step, artifact still uploaded"
+          else
+            echo "[pr-lookup] PR #$pr"
+          fi
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Ask Claude to diagnose
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CI_LOG_PATH: /tmp/ci-diagnose/fail.log
+          OUTPUT_PATH: /tmp/ci-diagnose/diagnose.md
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: node scripts/ci/diagnose-failure.mjs
+        # The script exits 1 on API failure but still writes a stub
+        # diagnosis — we want the comment step to post either way, so
+        # treat a non-zero exit here as non-fatal.
+        continue-on-error: true
+
+      - name: Post diagnosis as PR comment
+        if: ${{ steps.pr.outputs.number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ ! -s /tmp/ci-diagnose/diagnose.md ]; then
+            echo "[comment] diagnose.md missing or empty — nothing to post"
+            exit 0
+          fi
+          gh pr comment ${{ steps.pr.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --body-file /tmp/ci-diagnose/diagnose.md
+          echo "[comment] posted to PR #${{ steps.pr.outputs.number }}"
+
+      - name: Attach diagnosis as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-diagnose
+          path: /tmp/ci-diagnose/diagnose.md
+          if-no-files-found: warn
+          retention-days: 14

--- a/scripts/ci/diagnose-failure.mjs
+++ b/scripts/ci/diagnose-failure.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * Called by .github/workflows/ci-diagnose.yml when the main CI workflow
+ * (.github/workflows/ci.yml) fails. Reads the failed-step log, sends it
+ * to the Anthropic API with project-specific context, and writes a
+ * markdown diagnosis intended to be posted as a PR comment.
+ *
+ * Environment inputs:
+ *   ANTHROPIC_API_KEY   required      API key (repo secret)
+ *   ANTHROPIC_MODEL     optional      model id, default claude-sonnet-4-6
+ *   CI_LOG_PATH         required      path to failed-step log file
+ *   OUTPUT_PATH         required      where to write the markdown diagnosis
+ *   RUN_URL             optional      link to the failed CI run
+ *   PR_NUMBER           optional      PR number (for header only)
+ *   TRIGGER_SHA         optional      commit SHA that triggered CI
+ *
+ * Exit codes:
+ *   0   success — diagnosis written
+ *   1   API call failed — a stub diagnosis is still written so the PR
+ *       comment step can post something actionable about the failure
+ *   2   argument / input error (no key, no log file, etc.)
+ *
+ * Log handling:
+ *   The raw failed log can be hundreds of MB. We tail to the last N lines
+ *   with a byte cap so the prompt stays well under model context limits.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+const MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6';
+const LOG_PATH = process.env.CI_LOG_PATH;
+const OUTPUT_PATH = process.env.OUTPUT_PATH;
+const RUN_URL = process.env.RUN_URL || '';
+const PR_NUMBER = process.env.PR_NUMBER || '';
+const TRIGGER_SHA = process.env.TRIGGER_SHA || '';
+
+const MAX_LOG_LINES = 500;
+const MAX_LOG_BYTES = 50_000;
+const MAX_OUTPUT_TOKENS = 1200;
+
+function die(msg, code = 2) {
+  process.stderr.write(`[diagnose] ${msg}\n`);
+  process.exit(code);
+}
+
+function writeOutput(text) {
+  if (!OUTPUT_PATH) die('OUTPUT_PATH is required');
+  writeFileSync(OUTPUT_PATH, text);
+}
+
+function stubDiagnosis(reason) {
+  const parts = [
+    '<!-- ci-diagnose:auto -->',
+    '### CI failure diagnosis',
+    '',
+    '## Verdict',
+    'Diagnostic agent could not complete — manual review required.',
+    '',
+    '## Root cause',
+    `Automated diagnosis failed: ${reason}`,
+    '',
+    '## Proposed fix',
+    RUN_URL ? `Open the failed run at ${RUN_URL} and inspect the failed step manually.` : 'Open the failed CI run in the Actions tab and inspect the failed step manually.',
+    '',
+    '---',
+    `_Automated by ci-diagnose.yml · model: ${MODEL} · stub response_`,
+    '',
+  ];
+  return parts.join('\n');
+}
+
+if (!API_KEY) die('ANTHROPIC_API_KEY is required');
+if (!LOG_PATH) die('CI_LOG_PATH is required');
+if (!OUTPUT_PATH) die('OUTPUT_PATH is required');
+
+let rawLog;
+try {
+  rawLog = readFileSync(LOG_PATH, 'utf8');
+} catch (e) {
+  writeOutput(stubDiagnosis(`cannot read log at ${LOG_PATH}: ${e.message}`));
+  process.exit(1);
+}
+
+if (!rawLog.trim()) {
+  writeOutput(stubDiagnosis('log file was empty — no failed-step output captured'));
+  process.exit(1);
+}
+
+function tailLog(text, maxLines, maxBytes) {
+  const lines = text.split('\n');
+  const lineTrim = lines.length > maxLines;
+  const trimmed = lineTrim ? lines.slice(-maxLines) : lines;
+  let joined = trimmed.join('\n');
+  const byteTrim = joined.length > maxBytes;
+  if (byteTrim) joined = '...[truncated]...\n' + joined.slice(-maxBytes);
+  return { text: joined, truncated: lineTrim || byteTrim };
+}
+
+const { text: logExcerpt, truncated } = tailLog(rawLog, MAX_LOG_LINES, MAX_LOG_BYTES);
+
+const SYSTEM_PROMPT = `You are a CI failure diagnostician for the sc4sap repo — a Claude Code plugin for SAP On-Premise S/4HANA development.
+
+The CI workflow (.github/workflows/ci.yml) runs these steps sequentially on ubuntu-latest:
+  1. npm ci --ignore-scripts                 install deps, skip postinstall scripts
+  2. node scripts/bundle-keyring.mjs --verify  offline SHA-256 tamper detection against runtime-deps/keyring/integrity.json
+  3. node scripts/bundle-keyring.mjs --check   platform binary completeness (expects win32-x64-msvc, darwin-x64, darwin-arm64, linux-x64-gnu)
+  4. npx tsc --noEmit                          TypeScript typecheck across src/
+  5. npm run test:run                          vitest — 4 validation tests under tests/validation/
+
+Known failure patterns and their typical fixes:
+
+  - vitest assertion mismatch (most common after structural PRs):
+    The test fixtures enumerate agents/skills/configs and compare against actual file counts.
+    When a PR adds or removes files under agents/, skills/, configs/, etc., the hardcoded
+    expectations in tests/validation/*.test.ts go stale. Fix is almost always to update the
+    expected value in the test, not the source of truth.
+
+  - tsc TS#### error in src/:
+    Regression from a changed .ts file. Report the error code, file, and line.
+
+  - bundle-keyring.mjs --verify SHA-256 mismatch:
+    Should NOT happen under normal operation — the bundle directory has .gitattributes
+    "runtime-deps/** -text" to prevent CRLF drift on cross-platform checkout, and the
+    runtime-deps/keyring/integrity.json records per-file sha256. If this fires, suspect:
+      (a) someone modified the committed bundle by hand,
+      (b) .gitattributes is not being honored by the CI runner's checkout, or
+      (c) the integrity.json is stale and needs "bundle-keyring.mjs --refresh-integrity".
+
+  - bundle-keyring.mjs --check missing platform:
+    A platform binary directory was removed. Fix: trigger the rebundle.yml workflow
+    (Actions tab → Rebundle keyring → Run workflow) to restore the full 4-platform set.
+
+  - npm ci lockfile mismatch:
+    package.json and package-lock.json diverged. Fix: run "npm install" locally and
+    commit the updated lockfile.
+
+Output format — strict markdown, under 400 words total:
+
+## Verdict
+<one line: what failed, confidence level (high / medium / low)>
+
+## Root cause
+<2-4 sentences — explain the why, not just the what. Cite the log line(s) that prove it.>
+
+## Proposed fix
+<Specific file path and line number when possible. Include a unified-diff snippet or a command the maintainer can paste. If the fix requires inspecting context the log doesn't show, say which files to read first.>
+
+## Relevant log excerpt
+\`\`\`
+<the most diagnostic 10-20 lines from the log — verbatim, no summarization>
+\`\`\`
+
+Hard rules:
+- NEVER speculate beyond what the log supports. If uncertain, lower confidence and say so.
+- If the log is truncated and the failure reason isn't visible, report "log truncated before the failure site" and recommend fetching the full run log.
+- Focus on actionable fixes, not pedagogy.
+- No em dashes in code blocks or identifiers.`;
+
+const contextLines = [];
+if (PR_NUMBER) contextLines.push(`PR: #${PR_NUMBER}`);
+if (TRIGGER_SHA) contextLines.push(`commit: ${TRIGGER_SHA.slice(0, 7)}`);
+if (RUN_URL) contextLines.push(`run: ${RUN_URL}`);
+
+const userParts = [];
+if (contextLines.length) userParts.push('Context: ' + contextLines.join(' · '));
+userParts.push(
+  'Failed CI log' +
+    (truncated ? ` (last ${MAX_LOG_LINES} lines, ${MAX_LOG_BYTES} byte cap applied)` : '') +
+    ':',
+);
+userParts.push('```\n' + logExcerpt + '\n```');
+
+const requestBody = JSON.stringify({
+  model: MODEL,
+  max_tokens: MAX_OUTPUT_TOKENS,
+  system: SYSTEM_PROMPT,
+  messages: [{ role: 'user', content: userParts.join('\n\n') }],
+});
+
+let response;
+try {
+  const r = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    body: requestBody,
+  });
+  if (!r.ok) {
+    const errText = await r.text();
+    throw new Error(`HTTP ${r.status}: ${errText.slice(0, 400)}`);
+  }
+  response = await r.json();
+} catch (e) {
+  writeOutput(stubDiagnosis(`Claude API call failed — ${String(e).slice(0, 300)}`));
+  process.exit(1);
+}
+
+const diagnosis = response?.content?.[0]?.text;
+if (!diagnosis || typeof diagnosis !== 'string') {
+  writeOutput(stubDiagnosis('Claude API returned no text content'));
+  process.exit(1);
+}
+
+const headerLines = [
+  '<!-- ci-diagnose:auto -->',
+  '### CI failure diagnosis',
+];
+if (RUN_URL) headerLines.push(`Run: ${RUN_URL}`);
+if (TRIGGER_SHA) headerLines.push(`Commit: \`${TRIGGER_SHA.slice(0, 7)}\``);
+headerLines.push('');
+
+const footerLines = [
+  '',
+  '---',
+  `_Automated by ci-diagnose.yml · model: ${MODEL}_`,
+  '',
+];
+
+writeOutput(headerLines.join('\n') + diagnosis + footerLines.join('\n'));
+process.stderr.write(`[diagnose] OK — ${diagnosis.length} chars written to ${OUTPUT_PATH}\n`);

--- a/tests/validation/agents.test.ts
+++ b/tests/validation/agents.test.ts
@@ -30,7 +30,7 @@ describe('Agents Validation', () => {
       it('has valid frontmatter', () => {
         if (!existsSync(agentFile)) return;
         const content = readFileSync(agentFile, 'utf-8');
-        const match = content.match(/^---\n([\s\S]*?)\n---/);
+        const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
         expect(match, 'Missing frontmatter').toBeTruthy();
         const fm = match![1];
         expect(fm).toContain(`name: ${agent}`);

--- a/tests/validation/plugin-structure.test.ts
+++ b/tests/validation/plugin-structure.test.ts
@@ -10,9 +10,18 @@ describe('Plugin Structure Validation', () => {
     expect(existsSync(path)).toBe(true);
     const data = JSON.parse(readFileSync(path, 'utf-8'));
     expect(data.name).toBe('sc4sap');
-    expect(data.version).toBe('0.1.0');
+    const pkgVersion = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')).version;
+    expect(data.version, 'plugin.json version must match package.json').toBe(pkgVersion);
     expect(data.skills).toBe('./skills/');
     expect(data.mcpServers).toBe('./.mcp.json');
+  });
+
+  it('marketplace.json version matches package.json', () => {
+    const mpPath = join(ROOT, '.claude-plugin', 'marketplace.json');
+    const mp = JSON.parse(readFileSync(mpPath, 'utf-8'));
+    const pkgVersion = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')).version;
+    expect(mp.version, 'marketplace.json root version must match package.json').toBe(pkgVersion);
+    expect(mp.plugins[0].version, 'marketplace.json plugins[0].version must match package.json').toBe(pkgVersion);
   });
 
   it('marketplace.json exists and has required fields', () => {

--- a/tests/validation/skills.test.ts
+++ b/tests/validation/skills.test.ts
@@ -5,9 +5,10 @@ import { join } from 'path';
 const SKILLS_DIR = join(__dirname, '..', '..', 'skills');
 
 const EXPECTED_SKILLS = [
-  'setup', 'team', 'ralph', 'ralplan', 'ask', 'autopilot',
-  'deep-interview', 'mcp-setup', 'sap-doctor', 'sap-option', 'teams',
-  'release', 'create-object', 'analyze-code', 'analyze-symptom', 'program',
+  'analyze-cbo-obj', 'analyze-code', 'analyze-symptom', 'ask-consultant',
+  'compare-programs', 'create-object', 'create-program', 'deep-interview',
+  'mcp-setup', 'program-to-spec', 'release', 'sap-doctor',
+  'sap-option', 'setup', 'team', 'trust-session',
 ];
 
 describe('Skills Validation', () => {
@@ -29,7 +30,7 @@ describe('Skills Validation', () => {
       it('has valid frontmatter', () => {
         if (!existsSync(skillFile)) return;
         const content = readFileSync(skillFile, 'utf-8');
-        const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+        const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
         expect(frontmatterMatch, 'Missing frontmatter delimiters').toBeTruthy();
         const fm = frontmatterMatch![1];
         expect(fm).toContain('name:');

--- a/tests/validation/spro-configs.test.ts
+++ b/tests/validation/spro-configs.test.ts
@@ -55,13 +55,13 @@ describe('SPRO Config MD Files Validation', () => {
     });
   }
 
-  it('total config file count is 52', () => {
+  it('total config file count is 56', () => {
     let count = 0;
     for (const mod of MODULES) {
       for (const file of CONFIG_FILES) {
         if (existsSync(join(CONFIGS_DIR, mod, file))) count++;
       }
     }
-    expect(count).toBe(52);
+    expect(count).toBe(56);
   });
 });


### PR DESCRIPTION
## Summary
- Catch `main` up to `active` (currently stuck at 0.6.6 — PR #38). Brings in 0.6.7 → 0.6.11 releases and CI workflow additions.
- Sync `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` version fields to `0.6.11`. They had been stuck at 0.6.5 across 6 releases, which is why `/plugin` reported 0.6.5 as the latest available version.

## Releases included
- `0.6.7` Main_Thread_Dispatch enforcement layer (reverted in 0.6.8)
- `0.6.8` revert of 0.6.7 enforcement
- `0.6.9` bundle @napi-rs/keyring for git-clone installs
- `0.6.10` HUD walk-up, blocklist precedence, ship --prune
- `0.6.11` bundle integrity verification v1 (offline SHA-256)
- CI: GitHub Actions workflow with bundle integrity gate + workflow_dispatch rebundle + auto-diagnose CI failures

## Test plan
- [ ] Verify `/plugin` surfaces 0.6.11 as latest after merge
- [ ] Verify `package.json`, `plugin.json`, `marketplace.json` all read `0.6.11`
- [ ] CI bundle integrity gate passes

Generated with [Claude Code](https://claude.com/claude-code)